### PR TITLE
Add Unit Type Validation (Singapore Context) for ParseAddProperty

### DIFF
--- a/src/main/java/seedu/duke/CommandStructure.java
+++ b/src/main/java/seedu/duke/CommandStructure.java
@@ -1,5 +1,7 @@
 package seedu.duke;
 
+import java.util.Map;
+
 public class CommandStructure {
 
     public static final String COMMAND_ADD = "add";
@@ -31,4 +33,54 @@ public class CommandStructure {
     public static final String[] UNPAIR_FLAGS = {"ip/", "ic/"};
     public static final String[] CHECK_PROPERTY_FLAGS = {"ip/"};
     public static final String[] CHECK_CLIENT_FLAGS = {"ic/"};
+
+    //@@author OVReader
+    // Unit-Type Command Labels
+    // HDB Labels
+    public static final String UNIT_TYPE_ONE   = "HDB 2";
+    public static final String UNIT_TYPE_TWO   = "HDB 3";
+    public static final String UNIT_TYPE_THREE = "HDB 4";
+    public static final String UNIT_TYPE_FOUR  = "HDB 5";
+    public static final String UNIT_TYPE_FIVE  = "HDB 3Gen";
+    public static final String UNIT_TYPE_SIX   = "HDB ExFlat";
+    public static final String UNIT_TYPE_SEVEN = "HDB DBSS";
+    public static final String UNIT_TYPE_EIGHT = "HDB ExMsn";
+    public static final String UNIT_TYPE_NINE  = "HDB Jumbo";
+    public static final String UNIT_TYPE_TEN   = "HDB TH";
+
+    // Condominium Label
+    public static final String UNIT_TYPE_ELEVEN = "Condo";
+
+    // Penthouse Label
+    public static final String UNIT_TYPE_TWELVE = "PH";
+
+    // Landed Property Labels
+    public static final String UNIT_TYPE_THIRTEEN = "LP TH";
+    public static final String UNIT_TYPE_FOURTEEN = "LP SDH";
+    public static final String UNIT_TYPE_FIFTEEN  = "LP BGL";
+
+    // Actual Unit-Type
+    // HDB
+    public static final String ACTUAL_UNIT_TYPE_ONE   = "HDB 2-Room Flexi";
+    public static final String ACTUAL_UNIT_TYPE_TWO   = "HDB 3-Room";
+    public static final String ACTUAL_UNIT_TYPE_THREE = "HDB 4-Room";
+    public static final String ACTUAL_UNIT_TYPE_FOUR  = "HDB 5-Room";
+    public static final String ACTUAL_UNIT_TYPE_FIVE  = "HDB 3Gen";
+    public static final String ACTUAL_UNIT_TYPE_SIX   = "HDB Executive Flat";
+    public static final String ACTUAL_UNIT_TYPE_SEVEN = "HDB Design, Build and Sell Scheme (DBSS) Flat";
+    public static final String ACTUAL_UNIT_TYPE_EIGHT = "HDB Executive Maisonette";
+    public static final String ACTUAL_UNIT_TYPE_NINE  = "HDB Jumbo Flat";
+    public static final String ACTUAL_UNIT_TYPE_TEN   = "HDB Terrace House";
+
+    // Condominium
+    public static final String ACTUAL_UNIT_TYPE_ELEVEN = "Condominium";
+
+    // Penthouse
+    public static final String ACTUAL_UNIT_TYPE_TWELVE = "Penthouse";
+
+    // Landed Property
+    public static final String ACTUAL_UNIT_TYPE_THIRTEEN = "LP Terrace House";
+    public static final String ACTUAL_UNIT_TYPE_FOURTEEN = "LP Semi-Detached House";
+    public static final String ACTUAL_UNIT_TYPE_FIFTEEN  = "LP Bungalow";
+    //@@author
 }

--- a/src/main/java/seedu/duke/Messages.java
+++ b/src/main/java/seedu/duke/Messages.java
@@ -84,6 +84,35 @@ public class Messages {
     public static final String MESSAGE_INVALID_PRICE_FORMAT = "OOPS!!! Please enter positive number "
             + "(No letter/symbols, etc) for renting price per month for property";
 
+    public static final String MESSAGE_INVALID_UNIT_TYPE_LABEL = "OOPS!!! Please enter one of the following "
+            + "valid unit type labels as shown below (Case-Sensitive & Space-Sensitive):\n"
+            + "Format: t/<label>\n"
+            + LINE_BREAK
+            + "\nHDB Labels:\n"
+            + "  <HDB 2> for HDB 2-Room Flexi\n"
+            + "  <HDB 3> for HDB 3-Room\n"
+            + "  <HDB 4> for HDB 4-Room\n"
+            + "  <HDB 5> for HDB 5-Room\n"
+            + "  <HDB 3Gen> for HDB Third-Generation\n"
+            + "  <HDB ExFlat> for HDB Executive Flat\n"
+            + "  <HDB DBSS> for HDB Design, Build and Sell Scheme (DBSS) Flat\n"
+            + "  <HDB ExMsn> for HDB Executive Maisonette\n"
+            + "  <HDB Jumbo> for HDB Jumbo Flat\n"
+            + "  <HDB TH> for HDB Terrace House\n"
+            + LINE_BREAK
+            + "\nCondominium Label:\n"
+            + "  <Condo> for Condominium\n"
+            + LINE_BREAK
+            + "\nPenthouse Label:\n"
+            + "  <PH> for Penthouse\n"
+            + LINE_BREAK
+            + "\nLanded Property Labels\n"
+            + "  <LP TH> for LP Terrace House\n"
+            + "  <LP SDH> for LP Semi-Detached House\n"
+            + "  <LP BGL> for LP Bungalow\n"
+            + LINE_BREAK
+            + "\nNote: Only unit type labels (Singapore-Based) are accepted by the program";
+
     public static final String MESSAGE_INVALID_CONTACT_NUMBER = "OOPS!!! Please enter a valid Singapore Contact Number "
             + "(No extension)";
 

--- a/src/main/java/seedu/duke/Storage.java
+++ b/src/main/java/seedu/duke/Storage.java
@@ -519,18 +519,12 @@ public class Storage {
                                 pairingProperty = propertyList.getPropertyList().get(i);
                             }
                         }
-
                         pairingList.addPairing(pairingClient, pairingProperty);
-
                     }
                 }
             }
         } catch (FileNotFoundException e) {
             throw new RuntimeException(e);
         }
-
-
     }
-
-
 }

--- a/src/main/java/seedu/duke/exception/InvalidUnitTypeLabelException.java
+++ b/src/main/java/seedu/duke/exception/InvalidUnitTypeLabelException.java
@@ -1,0 +1,15 @@
+package seedu.duke.exception;
+
+//@@author OVReader
+
+import static seedu.duke.Messages.MESSAGE_INVALID_UNIT_TYPE_LABEL;
+
+/**
+ * Represents exception when invalid Unit Type Label is provided when adding property.
+ */
+public class InvalidUnitTypeLabelException extends DukeParseException {
+    @Override
+    public String toString() {
+        return MESSAGE_INVALID_UNIT_TYPE_LABEL;
+    }
+}

--- a/src/main/java/seedu/duke/parsermanager/ParseAddProperty.java
+++ b/src/main/java/seedu/duke/parsermanager/ParseAddProperty.java
@@ -12,11 +12,44 @@ import seedu.duke.exception.EmptyDetailException;
 import seedu.duke.exception.IncorrectFlagOrderException;
 import seedu.duke.exception.InvalidPriceFormatException;
 import seedu.duke.exception.InvalidSingaporeAddressException;
+import seedu.duke.exception.InvalidUnitTypeLabelException;
 import seedu.duke.exception.MissingFlagException;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 
 import static seedu.duke.CommandStructure.ADD_PROPERTY_FLAGS;
+import static seedu.duke.CommandStructure.UNIT_TYPE_ONE;
+import static seedu.duke.CommandStructure.UNIT_TYPE_TWO;
+import static seedu.duke.CommandStructure.UNIT_TYPE_THREE;
+import static seedu.duke.CommandStructure.UNIT_TYPE_FOUR;
+import static seedu.duke.CommandStructure.UNIT_TYPE_FIVE;
+import static seedu.duke.CommandStructure.UNIT_TYPE_SIX;
+import static seedu.duke.CommandStructure.UNIT_TYPE_SEVEN;
+import static seedu.duke.CommandStructure.UNIT_TYPE_EIGHT;
+import static seedu.duke.CommandStructure.UNIT_TYPE_NINE;
+import static seedu.duke.CommandStructure.UNIT_TYPE_TEN;
+import static seedu.duke.CommandStructure.UNIT_TYPE_ELEVEN;
+import static seedu.duke.CommandStructure.UNIT_TYPE_TWELVE;
+import static seedu.duke.CommandStructure.UNIT_TYPE_THIRTEEN;
+import static seedu.duke.CommandStructure.UNIT_TYPE_FOURTEEN;
+import static seedu.duke.CommandStructure.UNIT_TYPE_FIFTEEN;
+import static seedu.duke.CommandStructure.ACTUAL_UNIT_TYPE_ONE;
+import static seedu.duke.CommandStructure.ACTUAL_UNIT_TYPE_TWO;
+import static seedu.duke.CommandStructure.ACTUAL_UNIT_TYPE_THREE;
+import static seedu.duke.CommandStructure.ACTUAL_UNIT_TYPE_FOUR;
+import static seedu.duke.CommandStructure.ACTUAL_UNIT_TYPE_FIVE;
+import static seedu.duke.CommandStructure.ACTUAL_UNIT_TYPE_SIX;
+import static seedu.duke.CommandStructure.ACTUAL_UNIT_TYPE_SEVEN;
+import static seedu.duke.CommandStructure.ACTUAL_UNIT_TYPE_EIGHT;
+import static seedu.duke.CommandStructure.ACTUAL_UNIT_TYPE_NINE;
+import static seedu.duke.CommandStructure.ACTUAL_UNIT_TYPE_TEN;
+import static seedu.duke.CommandStructure.ACTUAL_UNIT_TYPE_ELEVEN;
+import static seedu.duke.CommandStructure.ACTUAL_UNIT_TYPE_TWELVE;
+import static seedu.duke.CommandStructure.ACTUAL_UNIT_TYPE_THIRTEEN;
+import static seedu.duke.CommandStructure.ACTUAL_UNIT_TYPE_FOURTEEN;
+import static seedu.duke.CommandStructure.ACTUAL_UNIT_TYPE_FIFTEEN;
+
 import static seedu.duke.Messages.EXCEPTION;
 import static seedu.duke.Messages.MESSAGE_ADD_PROPERTY_WRONG_FORMAT;
 
@@ -31,6 +64,7 @@ public class ParseAddProperty extends ParseAdd {
     private static final int PROPERTY_FLAG_SIZE = 4;
     private static final int PROPERTY_ADDRESS_INDEX = 1;
     private static final int PROPERTY_PRICE_INDEX = 2;
+    private static final int PROPERTY_UNIT_TYPE_INDEX = 3;
 
     private static final int FLAG_JUMPER_VALUE = 2;
     private static final int UNIT_VALUE = 1;
@@ -68,13 +102,36 @@ public class ParseAddProperty extends ParseAdd {
     // Accepts only positive whole number for price.
     private static final String VALID_PRICE_REGEX = "^[1-9]\\d*$";
 
+    private static HashMap<String, String> UNIT_TYPE_HASHMAP;
+
+
+
     public ParseAddProperty(String addCommandDescription, PropertyList propertyList) {
         this.commandDescription = addCommandDescription;
         this.propertyList = propertyList;
+
+        HashMap<String, String> unitTypeHashMap = new HashMap<>();
+        unitTypeHashMap.put(UNIT_TYPE_ONE, ACTUAL_UNIT_TYPE_ONE);
+        unitTypeHashMap.put(UNIT_TYPE_TWO, ACTUAL_UNIT_TYPE_TWO);
+        unitTypeHashMap.put(UNIT_TYPE_THREE, ACTUAL_UNIT_TYPE_THREE);
+        unitTypeHashMap.put(UNIT_TYPE_FOUR, ACTUAL_UNIT_TYPE_FOUR);
+        unitTypeHashMap.put(UNIT_TYPE_FIVE, ACTUAL_UNIT_TYPE_FIVE);
+        unitTypeHashMap.put(UNIT_TYPE_SIX, ACTUAL_UNIT_TYPE_SIX);
+        unitTypeHashMap.put(UNIT_TYPE_SEVEN, ACTUAL_UNIT_TYPE_SEVEN);
+        unitTypeHashMap.put(UNIT_TYPE_EIGHT, ACTUAL_UNIT_TYPE_EIGHT);
+        unitTypeHashMap.put(UNIT_TYPE_NINE, ACTUAL_UNIT_TYPE_NINE);
+        unitTypeHashMap.put(UNIT_TYPE_TEN, ACTUAL_UNIT_TYPE_TEN);
+        unitTypeHashMap.put(UNIT_TYPE_ELEVEN, ACTUAL_UNIT_TYPE_ELEVEN);
+        unitTypeHashMap.put(UNIT_TYPE_TWELVE, ACTUAL_UNIT_TYPE_TWELVE);
+        unitTypeHashMap.put(UNIT_TYPE_THIRTEEN, ACTUAL_UNIT_TYPE_THIRTEEN);
+        unitTypeHashMap.put(UNIT_TYPE_FOURTEEN, ACTUAL_UNIT_TYPE_FOURTEEN);
+        unitTypeHashMap.put(UNIT_TYPE_FIFTEEN, ACTUAL_UNIT_TYPE_FIFTEEN);
+        UNIT_TYPE_HASHMAP = unitTypeHashMap;
     }
 
     public Command parseCommand() throws  EmptyDetailException, MissingFlagException, IncorrectFlagOrderException,
-            InvalidSingaporeAddressException, InvalidPriceFormatException, DuplicatePropertyException {
+            InvalidSingaporeAddressException, InvalidPriceFormatException, InvalidUnitTypeLabelException,
+            DuplicatePropertyException {
         try {
             checkForEmptyDetails(commandDescription);
             ArrayList<String> propertyDetails = processCommandAddPropertyDetails(commandDescription);
@@ -128,7 +185,8 @@ public class ParseAddProperty extends ParseAdd {
     }
 
     private void validatePropertyDetails(ArrayList<String> propertyDetails) throws EmptyDetailException,
-            InvalidSingaporeAddressException, InvalidPriceFormatException, DuplicatePropertyException {
+            InvalidSingaporeAddressException, InvalidPriceFormatException, InvalidUnitTypeLabelException,
+            DuplicatePropertyException {
         // Checks for Missing Landlord Name, Property Address, Renting Price (SGD/month) and Unit-Type.
         for (String propertyDetail : propertyDetails) {
             checkForEmptyDetails(propertyDetail);
@@ -137,6 +195,8 @@ public class ParseAddProperty extends ParseAdd {
         // Checks Format for Address (Singapore) and Renting Price.
         checkForValidSingaporeAddress(propertyDetails.get(PROPERTY_ADDRESS_INDEX));
         checkForPriceNumberFormat(propertyDetails.get(PROPERTY_PRICE_INDEX));
+        propertyDetails.set(PROPERTY_UNIT_TYPE_INDEX,
+                checkForValidUnitType(propertyDetails.get(PROPERTY_UNIT_TYPE_INDEX)));
 
         // Duplicate Property refers to properties with the same address.
         checkForDuplicateProperty(propertyList, propertyDetails.get(PROPERTY_ADDRESS_INDEX));
@@ -176,6 +236,15 @@ public class ParseAddProperty extends ParseAdd {
         if (!hasValidPriceNumberFormat) {
             throw new InvalidPriceFormatException();
         }
+    }
+
+    private String checkForValidUnitType(String unitTypeLabel) throws  InvalidUnitTypeLabelException {
+        String actualUnitType = UNIT_TYPE_HASHMAP.get(unitTypeLabel);
+        boolean hasValidUnitType = (actualUnitType != null);
+        if (!hasValidUnitType) {
+            throw new InvalidUnitTypeLabelException();
+        }
+        return actualUnitType;
     }
 
     private void checkForDuplicateProperty(PropertyList propertyList, String propertyAddress)


### PR DESCRIPTION
Fix #120
Validation of unit-type added for add property features.
User must now choose from 15 existing unit-type labels (HDB, Condo, LP, etc)

However, there is a bug when loading unit-type from storage which will require @wilsonngja to resolve as issue #127   