### PR TITLE
Optimize add-related error messages

### DIFF
--- a/src/main/java/seedu/duke/Duke.java
+++ b/src/main/java/seedu/duke/Duke.java
@@ -48,7 +48,12 @@ public class Duke {
                 isCommandQuit = (command instanceof CommandQuit);
 
             } catch (DukeException e) {
+                // For issue #174
+                // Added some newline before and after exception message (Can try out to see what works best)
+                // Not done for Invalid Command Message
+                ui.printNewline();
                 ui.showExceptionMessage(e);
+                ui.printNewline();
             }
         } while (!isCommandQuit);
     }

--- a/src/main/java/seedu/duke/Messages.java
+++ b/src/main/java/seedu/duke/Messages.java
@@ -90,8 +90,8 @@ public class Messages {
             + "\nNote: Format is <space> sensitive; [Detail] must be provided; {Detail} is optional\n"
             + "Any deviation from format will lead to invalid address.";
 
-    public static final String MESSAGE_INVALID_PRICE_FORMAT = "OOPS!!! Please enter positive number "
-            + "(No letter/symbols, etc) for renting price per month for property";
+    public static final String MESSAGE_INVALID_PRICE_FORMAT = "OOPS!!! Please only enter positive integer "
+            + "for renting price per month of property";
 
     public static final String MESSAGE_INVALID_UNIT_TYPE_LABEL = "OOPS!!! Please enter one of the following "
             + "valid unit type labels as shown below (Case-Sensitive & Space-Sensitive):\n"
@@ -127,8 +127,8 @@ public class Messages {
 
     public static final String MESSAGE_INVALID_EMAIL = "OOPS!!! Please enter a valid Email Address";
 
-    public static final String MESSAGE_INVALID_BUDGET_FORMAT = "OOPS!!! Please enter positive number "
-            + "(No letter/symbols, etc) for budget";
+    public static final String MESSAGE_INVALID_BUDGET_FORMAT = "OOPS!!! Please only enter positive integer "
+            + "for budget";
 
     public static final String MESSAGE_DUPLICATE_PROPERTY = "OOPS!!! There is already an existing property with the"
             + " same address.";

--- a/src/main/java/seedu/duke/Messages.java
+++ b/src/main/java/seedu/duke/Messages.java
@@ -63,7 +63,7 @@ public class Messages {
     public static final String MESSAGE_ADD_PROPERTY_WRONG_FORMAT = "OOPS!!! To add a property, it requires "
             + "the following format and details:\n"
             + "Format: add -property n/NAME a/ADDRESS p/PRICE t/TYPE\n"
-            + "Example: add -property n/Bob Tan Bee Bee a/25 Lower Kent Ridge Rd, Singapore 119081 "
+            + "Example: add -property n/Bob Tan Bee Bee a/25 Lower Kent Ridge Rd, S119081 "
             + "p/1000 t/HDB 3";
 
     public static final String MESSAGE_ADD_CLIENT_WRONG_FORMAT = "OOPS!!! To add a client, it requires "
@@ -79,13 +79,13 @@ public class Messages {
             + LINE_BREAK
             + "\nLANDED PROPERTY:\n  Format:  "
             + "[Unit Number]<space>[Street Name],<space>Singapore<space>[Postal Code]\n"
-            + "  Example: 60 Aria Street, Singapore 602580\n"
+            + "  Example: 60 Aria Street, S602580\n"
             + LINE_BREAK
             + "\nBUILDINGS (e.g. HDBs, apartments, condominiums):\n"
             + "  Format (Without Building Name):\n  [Block Number]<space>[Street Name]<space>"
             + "#[Unit Level]-[Unit Number]{<space>[Building Name]},<space>Singapore<space>[Postal Code]\n"
-            + "  Example: 101 Marlow Street #12-05, Singapore 059020\n"
-            + "  Example (With Building Name): 101 Marlow Street #12-05 Clife Parkview, Singapore 059020\n"
+            + "  Example: 101 Marlow Street #12-05, S059020\n"
+            + "  Example (With Building Name): 101 Marlow Street #12-05 Clife Parkview, S059020\n"
             + LINE_BREAK
             + "\nNote: Format is <space> sensitive; [Detail] must be provided; {Detail} is optional\n"
             + "Any deviation from format will lead to invalid address.";

--- a/src/main/java/seedu/duke/Messages.java
+++ b/src/main/java/seedu/duke/Messages.java
@@ -8,6 +8,7 @@ public class Messages {
     public static final String EXCEPTION = "EXCEPTION";
     public static final String LINE_BREAK = "----------------------------------------------------------------------"
             + "----------";
+    public static final String INDENT = "        ";
 
     /* Confirmation Messages */
 
@@ -77,18 +78,22 @@ public class Messages {
             + "To add a property, A valid Singapore address must be provided\nwith the following "
             + "format and details:\n"
             + LINE_BREAK
-            + "\nLANDED PROPERTY:\n  Format:  "
-            + "[Unit Number]<space>[Street Name],<space>Singapore<space>[Postal Code]\n"
-            + "  Example: 60 Aria Street, S602580\n"
+            + "\n  Format:\n"
+            + INDENT + "[BLOCK NUMBER] [STREET NAME], S[POSTAL CODE]\n"
+            + INDENT + "[BLOCK NUMBER] [STREET NAME] #[unit level]-[unit number], S[POSTAL CODE]\n"
+            + INDENT + "[BLOCK NUMBER] [STREET NAME] #[unit level]-[unit number] [building name], S[POSTAL CODE]\n"
             + LINE_BREAK
-            + "\nBUILDINGS (e.g. HDBs, apartments, condominiums):\n"
-            + "  Format (Without Building Name):\n  [Block Number]<space>[Street Name]<space>"
-            + "#[Unit Level]-[Unit Number]{<space>[Building Name]},<space>Singapore<space>[Postal Code]\n"
-            + "  Example: 101 Marlow Street #12-05, S059020\n"
-            + "  Example (With Building Name): 101 Marlow Street #12-05 Clife Parkview, S059020\n"
+            + "\n  Example:\n"
+            + INDENT + "60 Aria Street, S602580\n"
+            + INDENT + "101 Marlow Street #12-05, S059020\n"
+            + INDENT + "101 Marlow Street #12-05 Clife Parkview, S059020\n"
             + LINE_BREAK
-            + "\nNote: Format is <space> sensitive; [Detail] must be provided; {Detail} is optional\n"
-            + "Any deviation from format will lead to invalid address.";
+            + "\n  Note:\n"
+            + INDENT + "1. Format requires single space between [DETAILS] (space sensitive).\n"
+            + INDENT + "2. [DETAIL] must be provided; [detail] is optional.\n"
+            + INDENT + "3. For landed property, treat [Block Number] as its unit number.\n"
+            + INDENT + "4. Any deviation from format will lead to invalid address.\n"
+            + LINE_BREAK;
 
     public static final String MESSAGE_INVALID_PRICE_FORMAT = "OOPS!!! Please only enter positive integer "
             + "for renting price per month of property";

--- a/src/main/java/seedu/duke/Ui.java
+++ b/src/main/java/seedu/duke/Ui.java
@@ -71,6 +71,10 @@ public class Ui {
         System.out.println(message);
     }
 
+    public void printNewline() {
+        System.out.print(System.lineSeparator());
+    }
+
     public void showWelcomeMessage() {
         showToUser(MESSAGE_WELCOME);
     }
@@ -86,12 +90,14 @@ public class Ui {
         int currentListSize = propertyList.getCurrentListSize();
         showToUser(MESSAGE_PROPERTY_ADDED);
         showToUser("  " + propertyList.getPropertyList().get(currentListSize - 1));
+        printNewline();
     }
 
     public void showClientAddedConfirmationMessage(ClientList clientList) {
         int currentListSize = clientList.getCurrentListSize();
         showToUser(MESSAGE_CLIENT_ADDED);
         showToUser("  " + clientList.getClientList().get(currentListSize - 1));
+        printNewline();
     }
 
 

--- a/src/main/java/seedu/duke/parsermanager/ParseAddClient.java
+++ b/src/main/java/seedu/duke/parsermanager/ParseAddClient.java
@@ -202,6 +202,7 @@ public class ParseAddClient extends ParseAdd {
 
     private static void showExistingDuplicateClient(Client client) {
         Ui ui = new Ui();
+        ui.printNewline();
         ui.showToUser(EXISTING_CLIENT + client.toString());
     }
 }

--- a/src/main/java/seedu/duke/parsermanager/ParseAddProperty.java
+++ b/src/main/java/seedu/duke/parsermanager/ParseAddProperty.java
@@ -278,6 +278,7 @@ public class ParseAddProperty extends ParseAdd {
 
     private static void showExistingDuplicateProperty(Property property) {
         Ui ui = new Ui();
+        ui.printNewline();
         ui.showToUser(EXISTING_PROPERTY + property.toString());
     }
 }

--- a/src/main/java/seedu/duke/parsermanager/ParseAddProperty.java
+++ b/src/main/java/seedu/duke/parsermanager/ParseAddProperty.java
@@ -82,7 +82,7 @@ public class ParseAddProperty extends ParseAdd {
             + "{1}[1-9]{1})|([1-9]{1}[0-9]{1,3}))([A-Z]?)";
     private static final String BUILDING_NAME_REGEX = " [^.!@#$%^&*()_+=<>\\s\\n?`~0-9,{}|-]([a-zA-Z\\s]+)[^.!@#$%^&*()"
             + "_+=<>\\s\\n?`~0-9,{}|-]";
-    private static final String POSTAL_CODE_REGEX = ", (Singapore [0-9]{6})$";
+    private static final String POSTAL_CODE_REGEX = ", (S[0-9]{6})$";
 
     // Singapore Landed Property Regex
     private static final String LANDED_PROPERTY_ADDRESS_REGEX = LANDED_PROPERTY_UNIT_NUMBER_REGEX + STREET_NAME_REGEX


### PR DESCRIPTION
Fix #180 (Error message for price/budget becomes more straightforward)
Fix #179 (Error message for address becomes more concise)
Fix #177 (Postal code requirement changes from `Singapore XXXXXX` to `SXXXXXX`, hence shorter validation and error messages)
Add some basic line separation for add-related outputs and general duke exceptions with regards to issue #174 (see code comment)
